### PR TITLE
Links to cross-origin destinations are unsafe

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -6,6 +6,7 @@
 				:href="fullLink"
 				class="gh-button"
 				target="_blank"
+				rel="noopener"
 			>
 				<component :is="iconComponentName" />
 				<slot />
@@ -15,6 +16,7 @@
 				:href="fullCountLink"
 				:target="hasCountLink ? '_blank' : null"
 				class="social-count"
+				rel="noopener"
 			>
 				{{ count | formatNumber }}
 			</a>


### PR DESCRIPTION
When you link to a page on another site using the target="_blank" attribute, you can expose your site to performance and security issues.

Adding rel="noopener" or rel="noreferrer" to your target="_blank" links avoids these issues.

For more information read https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools.